### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/finder": "^3.4",
-        "symfony/console": "^3.4",
-        "nikic/php-parser": "^3.1"
+        "symfony/console": "^3.4 || ~4.0 || ~5.0",
+        "symfony/finder": "^3.4 || ~4.0 || ~5.0",
+        "nikic/php-parser": "^4.10"
     },
     "config": {
         "preferred-install": "dist",


### PR DESCRIPTION
Fix conflict with [https://github.com/PrestaShopCorp/header-stamp](https://github.com/PrestaShopCorp/header-stamp)

```
Loading composer repositories with package information                                                                                                                                  Updating dependencies                                 
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires prestashop/autoindex dev-master -> satisfiable by prestashop/autoindex[dev-master].
    - Conclusion: don't install nikic/php-parser v3.1.3 (conflict analysis result)
    - Conclusion: don't install nikic/php-parser v4.10.2 (conflict analysis result)
    - Conclusion: don't install nikic/php-parser v3.1.4 (conflict analysis result)
    - Conclusion: don't install nikic/php-parser v4.10.3 (conflict analysis result)
    - Conclusion: don't install nikic/php-parser v3.1.5 (conflict analysis result)
    - Conclusion: don't install nikic/php-parser v4.10.4 (conflict analysis result)
    - Conclusion: don't install nikic/php-parser 3.x-dev (conflict analysis result)
    - Root composer.json requires prestashop/header-stamp dev-master -> satisfiable by prestashop/header-stamp[dev-master].
    - prestashop/autoindex dev-master requires nikic/php-parser ^3.1 -> satisfiable by nikic/php-parser[v3.1.0, ..., 3.x-dev].
    - You can only install one version of a package, so only one of these can be installed: nikic/php-parser[v3.1.0, ..., 3.x-dev, v4.10.0, ..., v4.10.4].
    - prestashop/header-stamp dev-master requires nikic/php-parser ^4.10 -> satisfiable by nikic/php-parser[v4.10.0, ..., v4.10.4].
    - Conclusion: don't install nikic/php-parser v4.10.1 (conflict analysis result)
```